### PR TITLE
Fixes a bug with the viewport not resizing after the window is resized

### DIFF
--- a/src/ui/MainApplication.h
+++ b/src/ui/MainApplication.h
@@ -55,7 +55,7 @@ void MainApplication::setup() {
 
 void MainApplication::resize() {
     mState.mainWindow.size = glm::vec2(getWindowSize());
-    setupModelView(mState);
+    onModelViewResize(mState);
 }
 
 void MainApplication::mouseDown(MouseEvent event) {

--- a/src/ui/ModelView.h
+++ b/src/ui/ModelView.h
@@ -7,12 +7,16 @@
 
 namespace pepr3d {
 
-inline void setupModelView(UiStateStore& state) {
+inline void onModelViewResize(UiStateStore& state) {
     ModelViewState& modelView = state.modelView;
-
     modelView.viewport = std::make_pair(glm::ivec2(0), glm::ivec2(state.mainWindow.size.x - state.sidePane.width,
                                                                   state.mainWindow.size.y - state.toolbar.height));
     modelView.camera.setAspectRatio(static_cast<float>(modelView.viewport.second.x) / modelView.viewport.second.y);
+}
+
+inline void setupModelView(UiStateStore& state) {
+    ModelViewState& modelView = state.modelView;
+    onModelViewResize(state);
     modelView.camera.lookAt(glm::vec3(3, 2, 2), glm::vec3(0, 0, 0));
 }
 


### PR DESCRIPTION
Now it recalculates the new viewport width and height as the window gets resized.

@tomasiser Is the start at **(0,0)** correct? shouldn't it start at **(0,toolbarheight)** or something like that?