### PR TITLE
Fix high CPU usage when window is minimized/hidden

### DIFF
--- a/src/ui/MainApplication.h
+++ b/src/ui/MainApplication.h
@@ -98,6 +98,12 @@ class MainApplication : public App {
 
    private:
     void setupIcon();
+    void willResignActive();
+    void didBecomeActive();
+    bool isWindowObscured();
+
+    bool mShouldSkipDraw = false;
+    bool mIsFocused = true;
 
     Toolbar mToolbar;
     SidePane mSidePane;


### PR DESCRIPTION
It works (partially only on Microsoft Windows) using a **heuristic** as no 100% working solutions were found.

- When window is **focused**, FPS is set to vertical sync framerate (typically **60** frames/second).
- When window is **not focused**, FPS is set to **24** frames/second (lower CPU usage while still being responsive for mouse hover, progress animations, etc.).
- When window is **not focused and not visible** (i.e., minimized or almost completely obscured by another window), rendering is disabled and update frequency is set to **2** per second. This check is implemented only for *Microsoft Windows*.

Closes #67.