### PR TITLE
Do not save original geometry in each state

### DIFF
--- a/src/geometry/Geometry.h
+++ b/src/geometry/Geometry.h
@@ -155,7 +155,7 @@ class Geometry {
     std::unique_ptr<GeometryProgress> mProgress;
 
     struct GeometryState {
-        std::vector<DataTriangle> triangles;
+        std::vector<size_t> triangleColors;
         std::map<size_t, TriangleDetail> triangleDetails;
         ColorManager::ColorMap colorMap;
     };

--- a/src/geometry/TriangleDetail.h
+++ b/src/geometry/TriangleDetail.h
@@ -349,10 +349,6 @@ class TriangleDetail {
     std::map<size_t, PolygonSet> mColoredPolys;
 
     DataTriangle mOriginal;
-
-    static const int VERTICES_PER_UNIT_CIRCLE = 50;
-    static const int MIN_VERTICES_IN_CIRCLE = 12;
-
 #ifdef PEPR3D_COLLECT_DEBUG_DATA
     std::vector<HistoryEntry> history;
 #endif


### PR DESCRIPTION
Reduces snapshot size, speeds up loading.